### PR TITLE
Extends MCP with Git Worktree Workflow Tools

### DIFF
--- a/.claude/commands/adhoc.md
+++ b/.claude/commands/adhoc.md
@@ -1,0 +1,42 @@
+# /adhoc
+
+Create a single worktree for quick tasks without the voting overhead.
+
+## Usage
+
+```
+/adhoc $ARGUMENTS
+```
+
+## Description
+
+This command creates a single git worktree branched from `origin/main` and launches Claude to complete the task. Perfect for bug fixes, small features, or quick experiments.
+
+## Examples
+
+```
+/adhoc Fix the null pointer exception in UserProfile component
+
+/adhoc Add input validation to the contact form
+
+/adhoc Update the README with installation instructions
+```
+
+## What happens
+
+1. Fetches latest from `origin/main`
+2. Creates a new worktree with a descriptive branch name
+3. Launches Claude in a new Terminal window
+4. Claude executes the task immediately
+5. Work is isolated in its own branch
+
+## Benefits
+
+- Quick start from clean `origin/main`
+- No voting overhead for simple tasks
+- Isolated development environment
+- Easy to test changes without affecting main branch
+
+## MCP Tool
+
+This command uses: `create_adhoc_worktree(task)`

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -1,0 +1,59 @@
+# /orchestrate
+
+Break down complex tasks into coordinated subtasks with parallel development.
+
+## Usage
+
+```
+/orchestrate $ARGUMENTS
+```
+
+Then follow the prompts to enter:
+1. Main task description
+2. Individual subtasks (one per line)
+
+## Description
+
+This command creates multiple worktrees, each dedicated to a specific subtask of a larger feature. Claude runs in parallel across all subtasks, allowing coordinated development of complex features.
+
+## Example
+
+```
+/orchestrate
+
+Main task: Implement user authentication system
+
+Subtasks:
+1. Create database models for users and sessions
+2. Build authentication API endpoints
+3. Implement JWT token generation and validation
+4. Create login/logout UI components
+5. Add authentication middleware and route protection
+```
+
+## What happens
+
+1. Creates separate worktrees for each subtask
+2. Each worktree gets a descriptive branch name
+3. Launches Claude in each worktree with its specific subtask
+4. All subtasks run in parallel
+5. Each worktree has a `SUBTASK_INSTRUCTIONS.md` file
+6. Development is coordinated across all subtasks
+
+## Best for
+
+- Large features requiring multiple components
+- System-wide refactoring
+- API development with models, endpoints, and tests
+- Any task that can be parallelized into independent parts
+
+## Tips
+
+- Break tasks into truly independent subtasks
+- Each subtask should be completable on its own
+- Consider dependencies between subtasks
+- Monitor all Terminal windows for progress
+
+## MCP Tool
+
+This command uses: `create_orchestrated_worktrees(task, subtasks)`

--- a/.claude/commands/voting-status.md
+++ b/.claude/commands/voting-status.md
@@ -1,0 +1,48 @@
+# /voting-status
+
+Check the status of all active voting sessions and evaluate implementations.
+
+## Usage
+
+```
+/voting-status $ARGUMENTS
+```
+
+## Description
+
+This command helps you monitor and manage active voting sessions. It shows all running sessions, their progress, and allows you to evaluate and select the best implementations.
+
+## What it shows
+
+- All active voting sessions with IDs
+- Task descriptions for each session
+- Progress (e.g., "3/5 complete, 5/5 executed")
+- Creation timestamps
+- Quick actions for each session
+
+## Example output
+
+```
+Active Voting Sessions:
+
+1. Session: abc12345
+   Task: "Refactor authentication system"
+   Status: 4/5 complete, 5/5 executed
+   Created: 2024-01-15 10:30:00
+
+2. Session: xyz78910
+   Task: "Add caching layer"
+   Status: 2/3 complete, 3/3 executed
+   Created: 2024-01-15 11:45:00
+```
+
+## Next steps
+
+For each session, you can:
+- `evaluate_implementations("session_id")` - See detailed rankings
+- `auto_select_best("session_id")` - Automatically select the best
+- `cleanup_session("session_id")` - Remove all worktrees
+
+## MCP Tool
+
+This command uses: `list_sessions()`

--- a/.claude/commands/voting.md
+++ b/.claude/commands/voting.md
@@ -1,0 +1,43 @@
+# /voting
+
+Create multiple worktree implementations using the voting pattern to find the best solution.
+
+## Usage
+
+```
+/voting $ARGUMENTS
+```
+
+## Description
+
+This command creates multiple git worktrees (default: 5) where Claude will implement the same task in different ways. After all implementations are complete, you can evaluate them and select the best one.
+
+## Examples
+
+```
+/voting Refactor the authentication system to use JWT tokens
+
+/voting Add comprehensive error handling to the API endpoints
+
+/voting Optimize the database queries for better performance
+```
+
+## What happens
+
+1. Creates 5 parallel git worktrees with descriptive names
+2. Launches Claude in each worktree with the task
+3. Each Claude instance implements the task independently
+4. You can evaluate all implementations and select the best one
+5. The selected implementation can be merged to main
+6. Other implementations are automatically cleaned up
+
+## Next steps
+
+After running this command:
+- Monitor progress with `list_sessions()`
+- Evaluate implementations with `evaluate_implementations(session_id)`
+- Auto-select the best with `auto_select_best(session_id, merge_to_main=true)`
+
+## MCP Tool
+
+This command uses: `create_voting_worktrees(task, num_variants=5)`

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# MCP Worktree Voting Server
+# MCP Git Worktree Workflows
 
-An MCP (Model Context Protocol) server that implements automated parallel development using git worktrees. Creates multiple implementations of the same task simultaneously, automatically evaluates them, and selects the best one.
+An MCP (Model Context Protocol) server that implements automated parallel development using git worktrees.
 
 ## 🚀 Key Features
-
-- **Fully Automated**: Claude automatically executes in each worktree
-- **Parallel Execution**: All implementations run concurrently for speed
-- **Smart Evaluation**: Automatic code analysis, test execution, and quality scoring
-- **Best Selection**: Intelligently ranks and selects the highest-quality implementation
+- **Voting Workflow**: Intelligently ranks and selects the highest-quality implementation
+- **Ad Hoc Workflow**: Quick single-worktree creation for simple tasks
+- **Orchestration Workflow**: Break complex tasks into subtasks with coordinated execution
 - **Clean Workflow**: Automatic cleanup of unsuccessful variants
 
 ## Installation
@@ -22,10 +20,10 @@ uv add fastmcp  # or pip install fastmcp
 ### Option A: Using Claude Code CLI (Recommended)
 ```bash
 # For project-specific use
-claude mcp add worktree-voting python /path/to/mcp-servers/mcp_worktree_voting.py
+claude mcp add worktree-workflows python /path/to/mcp-servers/worktree_workflows.py
 
 # For global use across all projects
-claude mcp add --scope user worktree-voting python /path/to/mcp-servers/mcp_worktree_voting.py
+claude mcp add --scope user worktree-workflows python /path/to/mcp-servers/worktree_workflows.py
 ```
 
 ### Option B: Manual Configuration
@@ -33,9 +31,9 @@ Add to your MCP configuration file:
 ```json
 {
   "mcpServers": {
-    "worktree-voting": {
+    "worktree-workflows": {
       "command": "python",
-      "args": ["/path/to/mcp-servers/mcp_worktree_voting.py"]
+      "args": ["/path/to/mcp-servers/worktree_workflows.py"]
     }
   }
 }
@@ -43,49 +41,39 @@ Add to your MCP configuration file:
 
 3. Restart Claude Code or use `/mcp` command to reconnect
 
-## 🔄 Automated Workflow
+## 🔄 Workflow Options
 
-### 1. Create Session (Everything Starts Here)
+### 1. Voting Pattern (Multiple Implementations)
 ```
-create_voting_session(
-  repository=lombardi
-  task="Rewrite the README.md ",
-  num_variants=5
+create_voting_worktrees(
+  task="Rewrite the README.md with better examples",
+  num_variants=5,
+  target_repo="lombardi"  # Optional: specify repository
 )
 ```
 
-**What happens automatically:**
-- Creates 5 git worktrees with separate branches
-- Launches Claude in each worktree with `--add-dir` flag
-- Claude implements the task in parallel across all worktrees
-- Evaluates each implementation (code changes, tests, quality metrics)
-- Ranks implementations by quality score
-
-### 2. Monitor Progress
+### 2. Ad Hoc Single Worktree
 ```
-list_sessions()
-```
-Shows execution status: `3/5 complete, 5/5 executed`
-
-### 3. Review Evaluations
-```
-evaluate_implementations(session_id="abc12345")
-```
-
-Returns detailed analysis:
-- **Ranked implementations** by quality score
-- **Code metrics**: files changed, lines added/removed
-- **Test results**: pass/fail status for each variant
-- **Recommendation**: Best implementation identified
-
-### 4. Auto-Select Best Implementation
-```
-auto_select_best(
-  session_id="abc12345",
-  merge_to_main=true
+create_adhoc_worktree(
+  task="Fix the login bug in auth.js",
+  target_repo="my-app"  # Optional
 )
 ```
-Automatically selects highest-scoring implementation and merges it.
+
+### 3. Orchestrated Subtasks
+```
+create_orchestrated_worktrees(
+  task="Implement user authentication system",
+  subtasks=[
+    "Create database models for users and sessions",
+    "Build authentication API endpoints",
+    "Implement JWT token generation and validation",
+    "Create login/logout UI components",
+    "Add authentication middleware and route protection"
+  ],
+  target_repo="my-app"  # Optional
+)
+```
 
 ## 📊 Evaluation Metrics
 
@@ -98,33 +86,49 @@ The system automatically evaluates implementations using:
 
 ## 🛠️ Available Tools
 
-### Core Workflow
-- **`create_voting_session`**: Creates worktrees and starts automated execution
+### Core Voting Workflow
+- **`create_voting_worktrees`**: Creates worktrees and starts automated execution
 - **`list_sessions`**: Monitor all active sessions and their progress
 - **`evaluate_implementations`**: Get detailed ranking and evaluation of all variants
 - **`auto_select_best`**: Automatically choose and finalize the best implementation
-
-### Manual Control (Optional)
-- **`get_worktree_info`**: Inspect specific worktree details
-- **`mark_implementation_complete`**: Manually mark implementations as done
 - **`finalize_best`**: Manually select a specific implementation
 - **`cleanup_session`**: Force cleanup of sessions
 
+### Additional Workflows
+- **`create_adhoc_worktree`**: Single worktree for quick tasks
+- **`create_orchestrated_worktrees`**: Multiple worktrees for coordinated subtasks
+
+### Utility Functions
+- **`get_worktree_info`**: Inspect specific worktree details
+- **`mark_implementation_complete`**: Manually mark implementations as done
+
 ## 💡 Example Use Cases
 
+### Voting Pattern
 Perfect for:
 - **Architecture Exploration**: Try different design patterns simultaneously
 - **Library Comparison**: Implement with various frameworks/libraries
 - **Algorithm Optimization**: Test multiple approaches to performance problems
 - **UI/UX Variants**: Create different interface implementations
-- **API Design**: Explore different endpoint structures
-- **Database Integration**: Try various ORM approaches or query strategies
 
-## 🎯 Quick Start Example
+### Ad Hoc Tasks
+Great for:
+- **Bug Fixes**: Quick isolation and resolution
+- **Small Features**: Rapid implementation without overhead
+- **Experiments**: Try ideas without affecting main branch
 
+### Orchestrated Development
+Ideal for:
+- **Large Features**: Break down and parallelize development
+- **System Refactoring**: Coordinate multiple related changes
+- **API Development**: Build endpoints, models, and tests in parallel
+
+## 🎯 Quick Start Examples
+
+### Example 1: Voting Pattern
 ```python
 # 1. Start automated voting session
-create_voting_session(
+create_voting_worktrees(
     task="Add Redis caching to the user service with error handling",
     num_variants=3
 )
@@ -142,9 +146,52 @@ auto_select_best(session_id="xyz789", merge_to_main=true)
 # Merges best implementation, cleans up others
 ```
 
+### Example 2: Quick Fix
+```python
+# Create single worktree for a bug fix
+create_adhoc_worktree(
+    task="Fix null pointer exception in user profile component"
+)
+# Claude starts immediately in new Terminal window
+```
+
+### Example 3: Feature Development
+```python
+# Break down complex feature into subtasks
+create_orchestrated_worktrees(
+    task="Add real-time notifications",
+    subtasks=[
+        "Set up WebSocket server infrastructure",
+        "Create notification database schema and models",
+        "Build notification API endpoints",
+        "Implement frontend notification component",
+        "Add notification preferences to user settings"
+    ]
+)
+# 5 Terminal windows open, each with Claude working on a subtask
+```
+
 ## ⚡ Performance Notes
 
 - **Concurrent Execution**: All Claude instances run in parallel
 - **Automatic Cleanup**: Failed/low-quality implementations are removed
 - **Resource Efficient**: Only keeps the winning implementation
 - **Fast Evaluation**: Uses git diff stats and automated test detection
+- **Smart Naming**: Worktrees include task description for easy identification
+
+## 🔧 Advanced Features
+
+### Worktree Naming
+- Branches and directories now include task descriptions
+- Format: `{session-id}-{task-slug}-{variant}`
+- Example: `abc123-fix-login-bug-var1`
+
+### Origin/Main Support
+- Ad hoc worktrees always branch from `origin/main`
+- Ensures clean starting point for isolated tasks
+- Automatically fetches latest changes
+
+### Terminal Integration
+- Automatically spawns Terminal windows (macOS)
+- Each worktree gets its own Claude session
+- No manual terminal management required

--- a/mcp_worktree_voting.py
+++ b/mcp_worktree_voting.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from fastmcp import FastMCP
+import re
 
 
 class WorktreeSession:
@@ -33,6 +34,8 @@ class WorktreeSession:
         self.evaluations: Dict[str, dict] = {}  # Track implementation evaluations
         self.created_at = datetime.now()
         self.base_branch = self._get_current_branch()
+        # Store task slug for consistent branch naming
+        self.task_slug = ''.join(c for c in task[:20] if c.isalnum() or c == ' ').replace(' ', '-').lower()
     
     def _get_current_branch(self) -> str:
         """Get the current git branch"""
@@ -43,6 +46,18 @@ class WorktreeSession:
             text=True
         )
         return result.stdout.strip() if result.returncode == 0 else "main"
+    
+    def _get_branch_name(self, session_id: str, worktree_id: str) -> str:
+        """Get the branch name for a worktree"""
+        return f"voting-{session_id}-{self.task_slug}-{worktree_id}"
+
+
+def _get_branch_name(session_id: str, worktree_id: str) -> str:
+    """Get the branch name for a worktree when session is not available"""
+    if session_id in sessions:
+        return sessions[session_id]._get_branch_name(session_id, worktree_id)
+    # Fallback for cleanup operations
+    return f"voting-{session_id}-{worktree_id}"
 
 
 # Initialize FastMCP
@@ -223,10 +238,13 @@ def create_voting_session(task: str, num_variants: int = 5, target_repo: str = N
     worktrees_dir = parent_path / f"{repo_path.name}.worktrees"
     worktrees_dir.mkdir(exist_ok=True)
     
+    # Create a task slug for naming (first 20 chars, alphanumeric only)
+    task_slug = ''.join(c for c in task[:20] if c.isalnum() or c == ' ').replace(' ', '-').lower()
+    
     for i in range(num_variants):
         variant_id = f"variant-{i+1}"
-        branch_name = f"voting-{session_id}-{variant_id}"
-        worktree_path = worktrees_dir / f"{session_id}-{variant_id}"
+        branch_name = f"voting-{session_id}-{task_slug}-{variant_id}"
+        worktree_path = worktrees_dir / f"{session_id}-{task_slug}-var{i+1}"
         
         # Create worktree
         result = subprocess.run(
@@ -324,7 +342,7 @@ def get_worktree_info(session_id: str, worktree_id: Optional[str] = None) -> str
             "worktree_id": worktree_id,
             "path": str(session.worktrees[worktree_id]),
             "completed": session.implementations[worktree_id],
-            "branch": f"voting-{session_id}-{worktree_id}"
+            "branch": self._get_branch_name(session_id, worktree_id)
         }
     else:
         info = {
@@ -335,7 +353,7 @@ def get_worktree_info(session_id: str, worktree_id: Optional[str] = None) -> str
                     "id": wid,
                     "path": str(path),
                     "completed": session.implementations[wid],
-                    "branch": f"voting-{session_id}-{wid}"
+                    "branch": self._get_branch_name(session_id, wid)
                 }
                 for wid, path in session.worktrees.items()
             ]
@@ -387,7 +405,7 @@ def evaluate_implementations(session_id: str) -> str:
             "worktree_id": wid,
             "path": str(path),
             "completed": session.implementations[wid],
-            "branch": f"voting-{session_id}-{wid}",
+            "branch": self._get_branch_name(session_id, wid),
             "execution_result": session.execution_results.get(wid, {}),
             "evaluation": session.evaluations.get(wid, {})
         }
@@ -489,7 +507,7 @@ def finalize_best(session_id: str, worktree_id: str, merge_to_main: bool = False
     if worktree_id not in session.worktrees:
         return f"Worktree {worktree_id} not found"
     
-    winner_branch = f"voting-{session_id}-{worktree_id}"
+    winner_branch = _get_branch_name(session_id, worktree_id)
     
     if merge_to_main:
         # Switch to base branch and merge
@@ -512,7 +530,7 @@ def finalize_best(session_id: str, worktree_id: str, merge_to_main: bool = False
     for wid, path in session.worktrees.items():
         if wid != worktree_id:
             subprocess.run(["git", "worktree", "remove", str(path), "--force"], cwd=session.base_path)
-            subprocess.run(["git", "branch", "-D", f"voting-{session_id}-{wid}"], cwd=session.base_path)
+            subprocess.run(["git", "branch", "-D", _get_branch_name(session_id, wid)], cwd=session.base_path)
             cleaned_up.append(wid)
     
     return json.dumps({
@@ -556,7 +574,7 @@ def cleanup_session(session_id: str, force: bool = False) -> str:
     # Remove all worktrees
     for wid, path in session.worktrees.items():
         subprocess.run(["git", "worktree", "remove", str(path), "--force"], cwd=session.base_path)
-        subprocess.run(["git", "branch", "-D", f"voting-{session_id}-{wid}"], cwd=session.base_path)
+        subprocess.run(["git", "branch", "-D", _get_branch_name(session_id, wid)], cwd=session.base_path)
     
     # Note: The worktrees directory is now shared across sessions,
     # so we don't remove it entirely. The git worktree remove command
@@ -569,6 +587,206 @@ def cleanup_session(session_id: str, force: bool = False) -> str:
         "session_id": session_id,
         "message": "All worktrees removed and session deleted"
     }, indent=2)
+
+
+@mcp.tool()
+def create_adhoc_worktree(task: str, target_repo: str = None) -> str:
+    """Create a single worktree from origin/main and execute task with Claude
+    
+    Args:
+        task: The task to execute in the worktree
+        target_repo: Name of the target repository directory (if not provided, looks for single repo)
+    """
+    worktree_id = str(uuid.uuid4())[:8]
+    parent_path = Path.cwd()
+    
+    # Find target repository
+    if target_repo:
+        repo_path = parent_path / target_repo
+    else:
+        # Look for a single git repository in current directory
+        git_repos = [d for d in parent_path.iterdir() if d.is_dir() and (d / ".git").exists()]
+        if len(git_repos) == 0:
+            return "Error: No git repository found in current directory"
+        elif len(git_repos) > 1:
+            return f"Error: Multiple git repositories found. Please specify target_repo parameter. Found: {[r.name for r in git_repos]}"
+        repo_path = git_repos[0]
+    
+    if not (repo_path / ".git").exists():
+        return f"Error: {repo_path} is not a git repository"
+    
+    # Create a task slug for naming
+    task_slug = ''.join(c for c in task[:30] if c.isalnum() or c == ' ').replace(' ', '-').lower()
+    
+    # Create worktrees directory alongside the repo
+    worktrees_dir = parent_path / f"{repo_path.name}.worktrees"
+    worktrees_dir.mkdir(exist_ok=True)
+    
+    # Create worktree from origin/main
+    branch_name = f"adhoc-{worktree_id}-{task_slug}"
+    worktree_path = worktrees_dir / f"adhoc-{worktree_id}-{task_slug}"
+    
+    # Fetch latest from origin and create worktree from origin/main
+    subprocess.run(["git", "fetch", "origin"], cwd=repo_path, capture_output=True)
+    result = subprocess.run(
+        ["git", "worktree", "add", "-b", branch_name, str(worktree_path), "origin/main"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True
+    )
+    
+    if result.returncode != 0:
+        return f"Error creating worktree: {result.stderr}"
+    
+    # Create task instructions
+    instructions_file = create_task_instructions(worktree_path, task, worktree_id, worktree_id)
+    
+    # Spawn terminal with Claude
+    spawn_terminal_for_worktree(worktree_path, task)
+    
+    response = {
+        "worktree_id": worktree_id,
+        "task": task,
+        "branch": branch_name,
+        "path": str(worktree_path),
+        "instruction_file": instructions_file,
+        "status": "Worktree created from origin/main and Claude session started",
+        "terminal_command": f'cd "{worktree_path}" && claude "{task}" --dangerously-skip-permissions'
+    }
+    
+    return json.dumps(response, indent=2)
+
+
+@mcp.tool()
+def create_orchestrated_worktrees(task: str, subtasks: list[str], target_repo: str = None) -> str:
+    """Create multiple worktrees for subtasks with orchestrated execution
+    
+    Args:
+        task: The main task description
+        subtasks: List of subtasks to execute in separate worktrees
+        target_repo: Name of the target repository directory (if not provided, looks for single repo)
+    """
+    session_id = str(uuid.uuid4())[:8]
+    parent_path = Path.cwd()
+    
+    # Find target repository
+    if target_repo:
+        repo_path = parent_path / target_repo
+    else:
+        # Look for a single git repository in current directory
+        git_repos = [d for d in parent_path.iterdir() if d.is_dir() and (d / ".git").exists()]
+        if len(git_repos) == 0:
+            return "Error: No git repository found in current directory"
+        elif len(git_repos) > 1:
+            return f"Error: Multiple git repositories found. Please specify target_repo parameter. Found: {[r.name for r in git_repos]}"
+        repo_path = git_repos[0]
+    
+    if not (repo_path / ".git").exists():
+        return f"Error: {repo_path} is not a git repository"
+    
+    # Create worktrees directory alongside the repo
+    worktrees_dir = parent_path / f"{repo_path.name}.worktrees"
+    worktrees_dir.mkdir(exist_ok=True)
+    
+    # Get current branch
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True
+    )
+    base_branch = result.stdout.strip() if result.returncode == 0 else "main"
+    
+    worktrees = {}
+    terminal_commands = []
+    instruction_files = []
+    
+    for i, subtask in enumerate(subtasks):
+        # Create a subtask slug for naming
+        subtask_slug = ''.join(c for c in subtask[:30] if c.isalnum() or c == ' ').replace(' ', '-').lower()
+        
+        worktree_id = f"subtask-{i+1}"
+        branch_name = f"orchestrated-{session_id}-{subtask_slug}"
+        worktree_path = worktrees_dir / f"{session_id}-{subtask_slug}"
+        
+        # Create worktree
+        result = subprocess.run(
+            ["git", "worktree", "add", "-b", branch_name, str(worktree_path)],
+            cwd=repo_path,
+            capture_output=True,
+            text=True
+        )
+        
+        if result.returncode != 0:
+            return f"Error creating worktree for subtask {i+1}: {result.stderr}"
+        
+        worktrees[worktree_id] = {
+            "path": str(worktree_path),
+            "branch": branch_name,
+            "subtask": subtask
+        }
+        
+        # Create task instructions for subtask
+        instructions = f"""# Orchestrated Task: Subtask {i+1}
+
+## Main Task
+{task}
+
+## Your Subtask
+{subtask}
+
+## Instructions
+1. Work in this directory: {worktree_path}
+2. Focus only on your specific subtask
+3. Complete the subtask thoroughly and with high quality
+4. Your work will be combined with other subtasks to complete the main task
+
+## How to start
+Open a terminal and run:
+```bash
+cd "{worktree_path}"
+claude
+```
+
+Then describe what you want to accomplish based on the subtask above.
+"""
+        
+        # Write instructions to the worktree
+        instructions_file = worktree_path / "SUBTASK_INSTRUCTIONS.md"
+        with open(instructions_file, 'w') as f:
+            f.write(instructions)
+        
+        instruction_files.append(str(instructions_file))
+        
+        command = f'claude "{subtask}" --dangerously-skip-permissions'
+        terminal_commands.append({
+            "worktree_id": worktree_id,
+            "path": str(worktree_path),
+            "command": f'cd "{worktree_path}" && {command}'
+        })
+        
+        # Spawn Terminal window for this subtask
+        spawn_terminal_for_worktree(worktree_path, subtask)
+    
+    response = {
+        "session_id": session_id,
+        "main_task": task,
+        "subtasks": subtasks,
+        "num_worktrees": len(subtasks),
+        "target_repo": repo_path.name,
+        "base_branch": base_branch,
+        "worktrees": worktrees,
+        "instruction_files": instruction_files,
+        "terminal_commands": terminal_commands,
+        "status": f"Created {len(subtasks)} worktrees for orchestrated execution",
+        "instructions": (
+            f"{len(subtasks)} Terminal windows have been opened, each with a Claude session for a specific subtask. "
+            f"Each worktree has a SUBTASK_INSTRUCTIONS.md file with the subtask details. "
+            f"Monitor progress across all worktrees to ensure coordinated completion of the main task."
+        )
+    }
+    
+    return json.dumps(response, indent=2)
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
 ]
 
 [project.scripts]
-mcp-worktree-voting = "mcp_worktree_voting:main"
+mcp-worktree-workflows = "worktree_workflows:main"
 
 [tool.uv.workspace]
 members = ["test_repo"]

--- a/worktree_workflows.py
+++ b/worktree_workflows.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-MCP Server for Git Worktree Voting Pattern
+MCP Server for Git Worktree Workflows
 
-Implements the voting pattern from Anthropic's agent workflows using git worktrees.
-Allows creating multiple worktree variants, implementing solutions in parallel,
-evaluating them, and selecting the best one.
+Implements multiple development workflows using git worktrees:
+- Voting pattern: Create multiple implementations and select the best
+- Ad hoc tasks: Single worktree for quick development
+- Orchestrated subtasks: Break complex tasks into parallel worktrees
 """
 
 import asyncio
@@ -61,7 +62,7 @@ def _get_branch_name(session_id: str, worktree_id: str) -> str:
 
 
 # Initialize FastMCP
-mcp = FastMCP("worktree-voting")
+mcp = FastMCP("worktree-workflows")
 
 # Global sessions store
 sessions: Dict[str, WorktreeSession] = {}
@@ -206,7 +207,7 @@ def setup_worktree_instructions(session_id: str):
 
 
 @mcp.tool()
-def create_voting_session(task: str, num_variants: int = 5, target_repo: str = None) -> str:
+def create_voting_worktrees(task: str, num_variants: int = 5, target_repo: str = None) -> str:
     """Create a new voting session with multiple worktrees
     
     Args:


### PR DESCRIPTION
This pull request introduces a suite of tools for managing Git worktrees within the MCP framework, enabling parallel development and experimentation.

Key changes:

- Introduces `/adhoc`, `/orchestrate`, and `/voting-status` commands for streamlined worktree management.
- Adds a new `create_adhoc_worktree` tool for creating single worktrees for quick tasks.
- Adds a new `create_orchestrated_worktrees` tool for breaking down complex tasks into subtasks and managing them in parallel worktrees.
- Updates the `create_voting_worktrees` tool and core workflow for voting implementations, including better branch naming and terminal integration.
- Improves the README with detailed explanations and usage examples for the new commands and tools.